### PR TITLE
Fix year regex

### DIFF
--- a/src/DSC.ParseTorrentName/Constants.cs
+++ b/src/DSC.ParseTorrentName/Constants.cs
@@ -13,6 +13,7 @@ namespace DSC.ParseTorrentName
 
         private static readonly List<Handler> _defaultHandlers = new List<Handler>
         {
+            new Handler(DefaultHandlerNames.Year, new Regex(@"(19|20)\d{2}(?!.*(19|20)\d{2})"), new HandlerOptions(type: "integer")),
             new Handler(DefaultHandlerNames.Year, new Regex(@"(?!^)[([]?((?:19[0-9]|20[012])[0-9])[)\]]?"), new HandlerOptions(type: "integer")),
             new Handler(DefaultHandlerNames.Resolution, new Regex(@"([0-9]{3,4}[pi])", RegexOptions.IgnoreCase), new HandlerOptions(type: "lowercase")),
             new Handler(DefaultHandlerNames.Resolution, new Regex(@"(4k)", RegexOptions.IgnoreCase), new HandlerOptions(type: "lowercase")),

--- a/src/DSC.ParseTorrentName/Constants.cs
+++ b/src/DSC.ParseTorrentName/Constants.cs
@@ -13,7 +13,7 @@ namespace DSC.ParseTorrentName
 
         private static readonly List<Handler> _defaultHandlers = new List<Handler>
         {
-            new Handler(DefaultHandlerNames.Year, new Regex(@"(19|20)\d{2}(?!.*(19|20)\d{2})"), new HandlerOptions(type: "integer")),
+            new Handler(DefaultHandlerNames.Year, new Regex(@"(?:19|20)\d{2}(?!.*(?:19|20)\d{2})"), new HandlerOptions(type: "integer")),
             new Handler(DefaultHandlerNames.Year, new Regex(@"(?!^)[([]?((?:19[0-9]|20[012])[0-9])[)\]]?"), new HandlerOptions(type: "integer")),
             new Handler(DefaultHandlerNames.Resolution, new Regex(@"([0-9]{3,4}[pi])", RegexOptions.IgnoreCase), new HandlerOptions(type: "lowercase")),
             new Handler(DefaultHandlerNames.Resolution, new Regex(@"(4k)", RegexOptions.IgnoreCase), new HandlerOptions(type: "lowercase")),


### PR DESCRIPTION
# Added New Regex for Year Handling in Torrent Name Parsing

## Description
This pull request introduces a new regular expression to enhance year detection in torrent name parsing. The regex added is:

```csharp
new Regex(@"(?:19|20)\d{2}(?!.*(?:19|20)\d{2})")
```

# Purpose of the New Regex
The new regex is designed to capture a year (YYYY, starting with 19 or 20) only if it is the last occurrence of a year in the given torrent name. This is particularly important for handling cases where multiple years are present in the name, and the last one typically represents the year of the movie or content, while earlier years may appear in the title or additional metadata.
The assertion is based on the fact that if there's two years in the torrent name, the latter one has more chances to be the film's year as if there was a year in the title it would be following the title which is usually the first to come.

# Context
In some torrent names, such as:
`Summer.of.1993.2018.1080p.BluRay.x264.DTS-HDGroup`

- The first year (1993) is part of the movie title.
- The second year (2018) represents the release year of the movie.

Without this enhancement, the parser could incorrectly select 1993 as the year, leading to inaccurate metadata extraction. The new regex ensures that only the relevant year (2018) is captured.

## Examples
### Before
![image](https://github.com/user-attachments/assets/45ed1f73-e235-4d2d-bd56-5c7f5d129965)

### After
![image](https://github.com/user-attachments/assets/19ac45f4-2fe4-4d96-bf7b-6d63554f35d0)



# Changes
- Added the new regex to the DefaultHandlerNames.Year handler.
- Ensured the regex works with existing HandlerOptions configuration (type: "integer").

# Testing
- Verified against names with multiple years to ensure only the last year is captured.
- Tested with various naming conventions to confirm compatibility with existing parsing logic.

# Motivation
This enhancement addresses a common issue in torrent name parsing where multiple years are present, but the final one is the most relevant (e.g., the release year of a movie). By refining the year detection logic, this change improves the accuracy of parsed metadata and reduces potential errors in year extraction.
